### PR TITLE
Order actions groups by first call appearance in log

### DIFF
--- a/src/main/java/com/google/devtools/build/remote/client/LogPrintingUtils.java
+++ b/src/main/java/com/google/devtools/build/remote/client/LogPrintingUtils.java
@@ -31,7 +31,7 @@ import io.grpc.Status.Code;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Methods for printing log files. */
@@ -107,7 +107,7 @@ public class LogPrintingUtils {
    * (earliest first).
    */
   private static void printEntriesGroupedByAction(PrintLogCommand options) throws IOException {
-    Map<String, Multiset<LogEntry>> actionMap = new HashMap<>();
+    Map<String, Multiset<LogEntry>> actionMap = new LinkedHashMap<>();
     int numSkipped = 0;
     try (InputStream in = new FileInputStream(options.file)) {
       LogEntry entry;


### PR DESCRIPTION
I think there ought to be some order to printing these log entries, and I think ordering them by first call log entry appearance is a reasonable choice. Assuming the log was dumped from Bazel, the order of the groups of calls should roughly be in the same order that the action started executing.